### PR TITLE
[Windows] Fixed CPU name not being detected

### DIFF
--- a/src/Sparkle/CSharp/SystemInfo.cs
+++ b/src/Sparkle/CSharp/SystemInfo.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Management;
 
 namespace Sparkle.CSharp;
 
@@ -46,24 +47,13 @@ public static class SystemInfo {
     /// Retrieves the processor name for the current system running on Windows.
     /// </summary>
     /// <returns>A string containing the processor name if successfully retrieved, otherwise "Unknown".</returns>
-    private static string GetProcessorNameWindows() {
+    private static string GetProcessorNameWindows()
+    {
         try {
-            ProcessStartInfo psi = new ProcessStartInfo {
-                FileName = "wmic",
-                Arguments = "cpu get Name",
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
+            var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_Processor");
 
-            using (Process? process = Process.Start(psi)) {
-                if (process != null) {
-                    using (StreamReader reader = process.StandardOutput) {
-                        string[] lines = reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
-                        return lines.Length > 1 ? lines[1].Trim() : "Unknown";
-                    }
-                }
-            }
+            foreach (var obj in searcher.Get())
+                return obj["Name"]?.ToString() ?? "Unknown";
         }
         catch (Exception ex) {
             // ignored.

--- a/src/Sparkle/Sparkle.csproj
+++ b/src/Sparkle/Sparkle.csproj
@@ -33,6 +33,7 @@
         <PackageReference Include="Jitter2" Version="2.6.2" />
         <PackageReference Include="LibNoise" Version="0.2.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Management" Version="9.0.4" />
     </ItemGroup>
   
     <!-- Icon -->


### PR DESCRIPTION
I noticed that when starting Sparkle, the CPU name isn’t shown. After a bit of digging, I found out that winc is deprecated. You can use the `ManagementObjectSearcher` class from `System.Management` to get the CPU name